### PR TITLE
Make subvolumes configurable in control.xml

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -444,6 +444,7 @@ partitioning_elements =
     | partitions
     | btrfs_increase_percentage
     | btrfs_default_subvolume
+    | subvolumes
 
 try_separate_home =		element try_separate_home { BOOLEAN }
 limit_try_home =		element limit_try_home { text }
@@ -460,6 +461,28 @@ vm_keep_unpartitioned_region =	element vm_keep_unpartitioned_region { BOOLEAN }
 use_separate_multipath_module =	element use_separate_multipath_module { BOOLEAN }
 btrfs_increase_percentage =	element btrfs_increase_percentage { INTEGER }
 btrfs_default_subvolume =	element btrfs_default_subvolume { text }
+
+## Optional, but if this element appears (even if it's empty),
+## the internal fallback list is not used
+subvolumes = element subvolumes {
+    LIST,
+    subvolume*
+}?
+
+subvolume = element subvolume {
+    ## subvolume path without leading /
+    element path { text } &
+
+    ## Optional: COW; default: true
+    element copy_on_write { BOOLEAN }? &
+
+    ## Optional: comma-separated architectures (default: all)
+    ## Prepend ! to negate
+    ## Example 1: i386,x86_64
+    ## Example 2: ppc,!board_powernv
+    ## (i.e. on PPC, but not if it's a board_powernv machine
+    element archs { text }?
+}
 
 # these have to be defined by Storage
 partitions = element partitions {
@@ -569,7 +592,7 @@ proposal_module = element proposal_module {
 proposal = element proposal {
     ## Unique ID of the proposal
     element unique_id { text } &
-    ## 
+    ##
     element label { text }? &
     ## Defines for which architectures is this proposal used.
     ## Comma-separated list of architectures as seen in

--- a/control/control.rng
+++ b/control/control.rng
@@ -887,6 +887,7 @@ selected for installation</a:documentation>
       <ref name="partitions"/>
       <ref name="btrfs_increase_percentage"/>
       <ref name="btrfs_default_subvolume"/>
+      <ref name="subvolumes"/>
     </choice>
   </define>
   <define name="try_separate_home">
@@ -958,6 +959,44 @@ selected for installation</a:documentation>
   <define name="btrfs_default_subvolume">
     <element name="btrfs_default_subvolume">
       <text/>
+    </element>
+  </define>
+  <define name="subvolumes">
+    <a:documentation>Optional, but if this element appears (even if it's empty),
+the internal fallback list is not used</a:documentation>
+    <optional>
+      <element name="subvolumes">
+        <ref name="LIST"/>
+        <zeroOrMore>
+          <ref name="subvolume"/>
+        </zeroOrMore>
+      </element>
+    </optional>
+  </define>
+  <define name="subvolume">
+    <element name="subvolume">
+      <interleave>
+        <element name="path">
+          <a:documentation>subvolume path without leading /</a:documentation>
+          <text/>
+        </element>
+        <optional>
+          <element name="copy_on_write">
+            <a:documentation>Optional: COW; default: true</a:documentation>
+            <ref name="BOOLEAN"/>
+          </element>
+        </optional>
+        <optional>
+          <element name="archs">
+            <a:documentation>Optional: comma-separated architectures (default: all)
+Prepend ! to negate
+Example 1: i386,x86_64
+Example 2: ppc,!board_powernv
+(i.e. on PPC, but not if it's a board_powernv machine</a:documentation>
+            <text/>
+          </element>
+        </optional>
+      </interleave>
     </element>
   </define>
   <!-- these have to be defined by Storage -->

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 27 14:51:19 CEST 2016 - shundhammer@suse.de
+
+- Make subvolumes configurable in control.xml (fate#321737)
+- 3.1.13.1
+
+-------------------------------------------------------------------
 Mon Mar 14 12:18:49 UTC 2016 - igonzalezsosa@suse.com
 
 - Added self_update_url (FATE#319716)

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        3.1.13
+Version:        3.1.13.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
https://fate.suse.com/321737

https://trello.com/c/JdvwBp5G/457-5-microos-12-sp2-move-default-subvolumes-to-control-file

The XML schema was already reviewed by imobach in https://github.com/yast/yast-installation-control/pull/22, but back then it did not have the correct target branch nor a version number nor a change log entry. Now it has all three of them.