### PR TITLE
Add minimalistic libzypp config

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -275,6 +275,7 @@ software_elements =
     | default_patterns
     | optional_default_patterns
     | upgrade
+    | minimalistic_libzypp_config
 
 ## Whether it is allowed to delete a package during upgrade
 delete_old_packages = element delete_old_packages { BOOLEAN }
@@ -428,6 +429,9 @@ upgrade = element upgrade {
 software = element software {
     software_elements*
 }
+
+## Minimalistic libzypp configuration (only requires, no documentation and no multiversion)
+minimalistic_libzypp_config = element minimalistic_libzypp_config { BOOLEAN }
 
 # software
 

--- a/control/control.rng
+++ b/control/control.rng
@@ -528,6 +528,7 @@ Absolut path is required.</a:documentation>
       <ref name="default_patterns"/>
       <ref name="optional_default_patterns"/>
       <ref name="upgrade"/>
+      <ref name="minimalistic_libzypp_config"/>
     </choice>
   </define>
   <define name="delete_old_packages">
@@ -879,6 +880,12 @@ selected for installation</a:documentation>
       <zeroOrMore>
         <ref name="software_elements"/>
       </zeroOrMore>
+    </element>
+  </define>
+  <define name="minimalistic_libzypp_config">
+    <a:documentation>Minimalistic libzypp configuration (only requires, no documentation and no multiversion)</a:documentation>
+    <element name="minimalistic_libzypp_config">
+      <ref name="BOOLEAN"/>
     </element>
   </define>
   <!-- software -->

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jan 13 15:36:15 UTC 2017 - igonzalezsosa@suse.com
+
+- Added new option to configure libzypp in a minimalistic way
+  (only required packages, no documentation and no multiversion)
+  (FATE#321764)
+- 3.1.13.9
+
+-------------------------------------------------------------------
 Fri Jan 13 09:09:44 UTC 2017 - jreidinger@suse.com
 
 - fix typo in last change breaking build of skelcd (bsc#1019659)

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        3.1.13.8
+Version:        3.1.13.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Add support for `minimalistic_libzypp_config` option. As you can see in [yast2-packager#212](https://github.com/yast/yast-packager/pull/212), libzypp will be configured to work in a "minimalistic" way (no recommended packages, no documentation and no multiversion).