### PR TITLE
Support to add system_roles through add-ons

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -814,32 +814,36 @@ update_workflow = element workflow {
     element stage { text } &
     element mode { text } &
     element insert_modules {
-	LIST,
-	element insert_module {
-	    element before { text } &
-	    element modules {
-		LIST,
-		module+
-	    }
-	}+
+        LIST,
+        element insert_module {
+            element before { text } &
+            element modules {
+                LIST,
+                module+
+            }
+        }+
     }? &
     element append_modules {
-	LIST,
-	module+
+        LIST,
+        module+
     }? &
     element remove_modules {
-	LIST,
-	element remove_module { text }+
+        LIST,
+        element remove_module { text }+
     }? &
     element replace_modules {
-	LIST,
-	element replace_module {
-	    element replace { text } &
-	    element modules {
-		LIST,
-		module+
-	    }
-	}+
+        LIST,
+        element replace_module {
+            element replace { text } &
+            element modules {
+                LIST,
+                module+
+            }
+        }+
+    }? &
+    element insert_system_roles {
+        LIST,
+        element insert_system_role { system_roles }
     }?
 }
 

--- a/control/control.rng
+++ b/control/control.rng
@@ -1667,6 +1667,14 @@ Valid for all stages if not explicitely defined.</a:documentation>
             </oneOrMore>
           </element>
         </optional>
+        <optional>
+          <element name="insert_system_roles">
+            <ref name="LIST"/>
+            <element name="insert_system_role">
+              <ref name="system_roles"/>
+            </element>
+          </element>
+        </optional>
       </interleave>
     </element>
   </define>

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 13 13:01:19 UTC 2017 - igonzalezsosa@suse.com
+
+- Support to add roles through addons (FATE#320772)
+- 3.2.4
+
+-------------------------------------------------------------------
 Mon Feb 13 08:52:08 UTC 2017 - jreidinger@suse.com
 
 - add option to have roles with no default (poo#14936)

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        3.2.3
+Version:        3.2.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Add support to insert system roles using add-ons (schema update for https://github.com/yast/yast-installation/pull/534).