### PR TITLE
Enable using home partition as generic separate data partition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     # disable rvm, use system Ruby
     - rvm reset
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "yast2-devtools rake" -g yast-rake
+    - sh ./travis_setup.sh -p "yast2-devtools rake gettext" -g yast-rake
 script:
     - make -f Makefile.cvs
     - make

--- a/control/control.rnc
+++ b/control/control.rnc
@@ -440,6 +440,7 @@ minimalistic_libzypp_config = element minimalistic_libzypp_config { BOOLEAN }
 partitioning_elements =
     try_separate_home
     | limit_try_home
+    | home_path
     | root_space_percent
     | root_base_size
     | root_max_size
@@ -460,6 +461,7 @@ partitioning_elements =
 
 try_separate_home =		element try_separate_home { BOOLEAN }
 limit_try_home =		element limit_try_home { text }
+home_path =                     element home_path { text }
 root_space_percent =		element root_space_percent { text }
 root_base_size =		element root_base_size { text }
 root_max_size =			element root_max_size { text }

--- a/control/control.rng
+++ b/control/control.rng
@@ -894,6 +894,7 @@ selected for installation</a:documentation>
     <choice>
       <ref name="try_separate_home"/>
       <ref name="limit_try_home"/>
+      <ref name="home_path"/>
       <ref name="root_space_percent"/>
       <ref name="root_base_size"/>
       <ref name="root_max_size"/>
@@ -920,6 +921,11 @@ selected for installation</a:documentation>
   </define>
   <define name="limit_try_home">
     <element name="limit_try_home">
+      <text/>
+    </element>
+  </define>
+  <define name="home_path">
+    <element name="home_path">
       <text/>
     </element>
   </define>

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 26 11:09:53 CEST 2017 - shundhammer@suse.de
+
+- Allow different mount point for home partition (Fate#323532)
+- 3.1.13.11
+
+-------------------------------------------------------------------
 Mon Jan 16 09:22:37 UTC 2017 - mfilka@suse.com
 
 - fate#321739

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        3.1.13.10
+Version:        3.1.13.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
https://trello.com/c/iOESXcm7/624-5-caasp-hack-separate-data-partition

_XML schema part_

CaaSP needs a separate partition for /var/lib/docker in the storage proposal, and since this would be very tricky to add to the existing proposal mechanism in yast-storage-old, we suggested to repurpose the home partition for that; it can now get another mount point from control.xml. The mechanics and the other parameters in control.xml (size etc.) are still taken from the home partition / volume.
