### PR TITLE
mark obsolete keys

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -147,19 +147,25 @@ write_hostname_to_hosts =		element write_hostname_to_hosts { BOOLEAN }
 dhclient_set_hostname =		element dhclient_set_hostname { BOOLEAN }
 ## Defines whether startup scripts should run in a parallel mode.
 ## This speeds the starting up but it is worse for debugging.
+## *obsolete* without replacement
 run_init_scripts_in_parallel =		element run_init_scripts_in_parallel { BOOLEAN }
 inform_about_suboptimal_distribution =	element inform_about_suboptimal_distribution { BOOLEAN }
 skip_language_dialog =			element skip_language_dialog { BOOLEAN }
 ## Defines whether an AytoYaST cloning feature should be enabled
 enable_clone =				element enable_clone { BOOLEAN }
 ## Default value for 'send hardware data' with registration
+## *obsolete* without replacement
 enable_register_hwdata =		element enable_register_hwdata { BOOLEAN }
 ## Default value for 'send optional system data' with registration
+## *obsolete* without replacement
 enable_register_optional =		element enable_register_optional { BOOLEAN }
 ## Defines if by default os probing should be disabled see. Default is false. (bnc#884007)
 disable_os_prober =			element disable_os_prober { BOOLEAN }
+## *obsolete* without replacement
 display_register_forcereg =		element display_register_forcereg { BOOLEAN }
+## *obsolete* without replacement
 disable_register_w3m =			element disable_register_w3m { BOOLEAN }
+## *obsolete* without replacement
 register_monthly =			element register_monthly { BOOLEAN }
 manual_online_update =			element manual_online_update { BOOLEAN }
 root_password_as_first_user =		element root_password_as_first_user { BOOLEAN }
@@ -172,6 +178,7 @@ addons_default =			element addons_default { BOOLEAN }
 ## between the first and the second stage of installation
 kexec_reboot =				element kexec_reboot { BOOLEAN }
 ## Defines whether a special runlevel 4 should be offered
+## *obsolete* without replacement
 rle_offer_rulevel_4 =			element rle_offer_rulevel_4 { BOOLEAN }
 default_ntp_setup =			element default_ntp_setup { BOOLEAN }
 ## Defines whether kdump is enabled by default
@@ -278,6 +285,7 @@ software_elements =
     | minimalistic_libzypp_config
 
 ## Whether it is allowed to delete a package during upgrade
+## *obsolete* without replacement
 delete_old_packages = element delete_old_packages { BOOLEAN }
 selection_type = element selection_type { SYMBOL }
 ## System scenario selected by default.
@@ -316,6 +324,7 @@ kernel_packages = element kernel_packages {
     element package { text }+
 }
 
+## *obsolete* without replacement
 delete_old_packages_reverse_list = element delete_old_packages_reverse_list {
     LIST,
     element regexp_item { text }+

--- a/control/control.rng
+++ b/control/control.rng
@@ -231,7 +231,8 @@ more detailed log entries</a:documentation>
   </define>
   <define name="run_init_scripts_in_parallel">
     <a:documentation>Defines whether startup scripts should run in a parallel mode.
-This speeds the starting up but it is worse for debugging.</a:documentation>
+This speeds the starting up but it is worse for debugging.
+*obsolete* without replacement</a:documentation>
     <element name="run_init_scripts_in_parallel">
       <ref name="BOOLEAN"/>
     </element>
@@ -253,13 +254,15 @@ This speeds the starting up but it is worse for debugging.</a:documentation>
     </element>
   </define>
   <define name="enable_register_hwdata">
-    <a:documentation>Default value for 'send hardware data' with registration</a:documentation>
+    <a:documentation>Default value for 'send hardware data' with registration
+*obsolete* without replacement</a:documentation>
     <element name="enable_register_hwdata">
       <ref name="BOOLEAN"/>
     </element>
   </define>
   <define name="enable_register_optional">
-    <a:documentation>Default value for 'send optional system data' with registration</a:documentation>
+    <a:documentation>Default value for 'send optional system data' with registration
+*obsolete* without replacement</a:documentation>
     <element name="enable_register_optional">
       <ref name="BOOLEAN"/>
     </element>
@@ -271,16 +274,19 @@ This speeds the starting up but it is worse for debugging.</a:documentation>
     </element>
   </define>
   <define name="display_register_forcereg">
+    <a:documentation>*obsolete* without replacement</a:documentation>
     <element name="display_register_forcereg">
       <ref name="BOOLEAN"/>
     </element>
   </define>
   <define name="disable_register_w3m">
+    <a:documentation>*obsolete* without replacement</a:documentation>
     <element name="disable_register_w3m">
       <ref name="BOOLEAN"/>
     </element>
   </define>
   <define name="register_monthly">
+    <a:documentation>*obsolete* without replacement</a:documentation>
     <element name="register_monthly">
       <ref name="BOOLEAN"/>
     </element>
@@ -328,7 +334,8 @@ between the first and the second stage of installation</a:documentation>
     </element>
   </define>
   <define name="rle_offer_rulevel_4">
-    <a:documentation>Defines whether a special runlevel 4 should be offered</a:documentation>
+    <a:documentation>Defines whether a special runlevel 4 should be offered
+*obsolete* without replacement</a:documentation>
     <element name="rle_offer_rulevel_4">
       <ref name="BOOLEAN"/>
     </element>
@@ -532,7 +539,8 @@ Absolut path is required.</a:documentation>
     </choice>
   </define>
   <define name="delete_old_packages">
-    <a:documentation>Whether it is allowed to delete a package during upgrade</a:documentation>
+    <a:documentation>Whether it is allowed to delete a package during upgrade
+*obsolete* without replacement</a:documentation>
     <element name="delete_old_packages">
       <ref name="BOOLEAN"/>
     </element>
@@ -639,6 +647,7 @@ Comma and/or space-separated list of packages</a:documentation>
     </element>
   </define>
   <define name="delete_old_packages_reverse_list">
+    <a:documentation>*obsolete* without replacement</a:documentation>
     <element name="delete_old_packages_reverse_list">
       <ref name="LIST"/>
       <oneOrMore>


### PR DESCRIPTION
This change is done only for documentation purpose. It is side effect of changing control files for SLE15 and basically just mark obsolete keys that are no longer read from YaST.