### PR TITLE
Make fs type for home and root configurable

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -441,6 +441,8 @@ partitioning_elements =
     try_separate_home
     | limit_try_home
     | home_path
+    | home_fs
+    | root_fs
     | root_space_percent
     | root_base_size
     | root_max_size
@@ -462,6 +464,8 @@ partitioning_elements =
 try_separate_home =		element try_separate_home { BOOLEAN }
 limit_try_home =		element limit_try_home { text }
 home_path =                     element home_path { text }
+home_fs =                       element home_fs { text }
+root_fs =                       element root_fs { text }
 root_space_percent =		element root_space_percent { text }
 root_base_size =		element root_base_size { text }
 root_max_size =			element root_max_size { text }

--- a/control/control.rng
+++ b/control/control.rng
@@ -895,6 +895,8 @@ selected for installation</a:documentation>
       <ref name="try_separate_home"/>
       <ref name="limit_try_home"/>
       <ref name="home_path"/>
+      <ref name="home_fs"/>
+      <ref name="root_fs"/>
       <ref name="root_space_percent"/>
       <ref name="root_base_size"/>
       <ref name="root_max_size"/>
@@ -926,6 +928,16 @@ selected for installation</a:documentation>
   </define>
   <define name="home_path">
     <element name="home_path">
+      <text/>
+    </element>
+  </define>
+  <define name="home_fs">
+    <element name="home_fs">
+      <text/>
+    </element>
+  </define>
+  <define name="root_fs">
+    <element name="root_fs">
       <text/>
     </element>
   </define>

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 16 11:39:45 CEST 2017 - shundhammer@suse.de
+
+- Make filesystem type for home and root configurable (bsc#1051762)
+- 3.1.13.12
+
+-------------------------------------------------------------------
 Mon Jun 26 11:09:53 CEST 2017 - shundhammer@suse.de
 
 - Allow different mount point for home partition (Fate#323532)

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        3.1.13.11
+Version:        3.1.13.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
https://trello.com/c/SQQ1x4Bg/691-5-suse-caasp-10-p2-1051762-docker-on-xfs-by-default

This makes the filesystem type for both home and root in the storage proposal configurable: When home_fs is configurable, root_fs is only a heartbeat away, and it's trivial to add it at the same time.