### PR TITLE
Merged SLE-12-SP3-CASP branch to master

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -450,6 +450,8 @@ partitioning_elements =
     try_separate_home
     | limit_try_home
     | home_path
+    | home_fs
+    | root_fs
     | root_space_percent
     | root_base_size
     | root_max_size
@@ -471,6 +473,8 @@ partitioning_elements =
 try_separate_home =		element try_separate_home { BOOLEAN }
 limit_try_home =		element limit_try_home { text }
 home_path =                     element home_path { text }
+home_fs =                       element home_fs { text }
+root_fs =                       element root_fs { text }
 root_space_percent =		element root_space_percent { text }
 root_base_size =		element root_base_size { text }
 root_max_size =			element root_max_size { text }

--- a/control/control.rng
+++ b/control/control.rng
@@ -904,6 +904,8 @@ selected for installation</a:documentation>
       <ref name="try_separate_home"/>
       <ref name="limit_try_home"/>
       <ref name="home_path"/>
+      <ref name="home_fs"/>
+      <ref name="root_fs"/>
       <ref name="root_space_percent"/>
       <ref name="root_base_size"/>
       <ref name="root_max_size"/>
@@ -935,6 +937,16 @@ selected for installation</a:documentation>
   </define>
   <define name="home_path">
     <element name="home_path">
+      <text/>
+    </element>
+  </define>
+  <define name="home_fs">
+    <element name="home_fs">
+      <text/>
+    </element>
+  </define>
+  <define name="root_fs">
+    <element name="root_fs">
       <text/>
     </element>
   </define>

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Tue Aug 22 12:02:29 CEST 2017 - shundhammer@suse.de
+
+- Merged SLE-12-SP3-CASP branch to master
+- 3.3.0
+
+-------------------------------------------------------------------
+Thu Aug 17 15:13:44 CEST 2017 - shundhammer@suse.de
+
+- Make filesystem type for home and root configurable in control.xml
+  (bsc#1051762)
+
+-------------------------------------------------------------------
 Mon Jun 26 11:09:53 CEST 2017 - shundhammer@suse.de
 
 - Allow different mount point for home partition (Fate#323532)

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        3.2.6
+Version:        3.3.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
skelcd-control-CAAP needs this updated XML schema to build because it lives in master and is also submitted to factory where those latest CaaSP changes are not yet available. This commit makes them available.

Even if this feature is currently not used at all in factory, this prevents build breakages.