### PR TITLE
Remove old setting from ng format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,22 @@
 [![Travis Build](https://travis-ci.org/yast/yast-installation-control.svg?branch=master)](https://travis-ci.org/yast/yast-installation-control)
 [![Jenkins Build](http://img.shields.io/jenkins/s/https/ci.opensuse.org/yast-installation-control-master.svg)](https://ci.opensuse.org/view/Yast/job/yast-installation-control-master/)
 
+## Notes
+
+Distribute also the generated control.rng file, the reason is that "trang"
+is a Java tool which adds huge dependency in OBS.
+
+The conversion needs to be done manually (by running "make")
+and the converted RNG file must be committed to Git.
+
+```
+make -f Makefile.cvs
+make
+```
+
+At build time the RNG file from tarball will have a newer time stamp
+and thus it will not need rebuild/update making "trang" unnecessary.
+
 See also the [documentation for the control file][doc].
 
 [doc]: https://github.com/yast/yast-installation/blob/master/doc/control-file.md

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ task :check_rng_status do
 
   # RNC must not be newer than RNG
   if rng_commit_time.to_i < rnc_commit_time.to_i
-    raise "Error: control/control.rng is outdated, regenerate it from control/control.rnc file"
+    raise "Error: control/control.rng is outdated, regenerate it from control/control.rnc file (by running \"make\")"
   end
 end
 

--- a/control/control.rnc
+++ b/control/control.rnc
@@ -452,7 +452,6 @@ ng_partitioning_elements =
     partitioning_proposal
     & partitioning_volumes
     & expert_partitioner_warning?
-    & use_separate_multipath_module?
 
 # legacy: the old stuff, mixed together
 legacy_partitioning_elements =

--- a/control/control.rng
+++ b/control/control.rng
@@ -898,9 +898,6 @@ selected for installation</a:documentation>
       <optional>
         <ref name="expert_partitioner_warning"/>
       </optional>
-      <optional>
-        <ref name="use_separate_multipath_module"/>
-      </optional>
     </interleave>
   </define>
   <!-- legacy: the old stuff, mixed together -->


### PR DESCRIPTION
Setting `use_separate_multipath_module` is removed from ng format. This setting is not used anymore.

See PBI https://trello.com/c/nujLPA7G/342-2-sles15-p1-1087486-storage-ng-various-storage-ng-related-controlxml-parameters-not-working.