### PR TITLE
Configuration management support

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -1058,25 +1058,47 @@ update = element update {
 # update
 
 configuration_management = element configuration_management {
-    element type { "salt" | "puppet" }? &
+    # Configuration managment system to use
+    element type { "salt" | "puppet" } &
+    # Host name or IP address of the master server
     element master { text }? &
+    # Number of attempts when trying to connect to the master server
     element auth_attempts { INTEGER }? &
+    # Time between attempts to connect to the master server
     element auth_time_out { INTEGER }? &
+    # Path to an HTTTP(S) server, hard disk, USB driver or similar containing the
+    # private/public keys to connect to the master server
     element keys_url { text }? &
+    # Enable the configuration management system services after the installation
     element enable_services { BOOLEAN }? &
 
     # Salt specific
-    element formulas_roots { text }? &
+
+    # Path to write Pillar data
     element pillar_root { text }? &
+    # URL to read Pillar data from
     element pillar_url { text }? &
-    element states_roots { text }? &
+    # Paths to search for formulas
+    element formulas_roots {
+      LIST,
+      element formulas_root { text }+
+    }? &
+    # Paths to search for states
+    element states_roots {
+      LIST,
+      element states_root { text }+
+    }? &
+    # URL to get states from
     element states_url { text }? &
+    # List of states/formulas to enable
     element enabled_states {
       LIST,
       element state { text }+
     }? &
 
     # Puppet specific
+
+    # URL to read Puppet modules from
     element modules_url { text }?
 }
 

--- a/control/control.rnc
+++ b/control/control.rnc
@@ -1057,6 +1057,29 @@ update = element update {
 
 # update
 
+configuration_management = element configuration_management {
+    element type { "salt" | "puppet" }? &
+    element master { text }? &
+    element auth_attempts { INTEGER }? &
+    element auth_time_out { INTEGER }? &
+    element keys_url { text }? &
+    element enable_services { BOOLEAN }? &
+
+    # Salt specific
+    element formulas_roots { text }? &
+    element pillar_root { text }? &
+    element pillar_url { text }? &
+    element states_roots { text }? &
+    element states_url { text }? &
+    element enabled_states {
+      LIST,
+      element state { text }+
+    }? &
+
+    # Puppet specific
+    element modules_url { text }?
+}
+
 # not more than one partitioning element
 productDefines_elements =
     textdomain*
@@ -1071,6 +1094,7 @@ productDefines_elements =
     & inst_finish_stages*
     & update*
     & system_roles*
+    & configuration_management?
 
 start = element productDefines {
     productDefines_elements

--- a/control/control.rng
+++ b/control/control.rng
@@ -2232,66 +2232,89 @@ Valid for all stages if not explicitely defined.</a:documentation>
   <define name="configuration_management">
     <element name="configuration_management">
       <interleave>
+        <!-- Configuration managment system to use -->
+        <element name="type">
+          <choice>
+            <value>salt</value>
+            <value>puppet</value>
+          </choice>
+        </element>
         <optional>
-          <element name="type">
-            <choice>
-              <value>salt</value>
-              <value>puppet</value>
-            </choice>
-          </element>
-        </optional>
-        <optional>
+          <!-- Host name or IP address of the master server -->
           <element name="master">
             <text/>
           </element>
         </optional>
         <optional>
+          <!-- Number of attempts when trying to connect to the master server -->
           <element name="auth_attempts">
             <ref name="INTEGER"/>
           </element>
         </optional>
         <optional>
+          <!-- Time between attempts to connect to the master server -->
           <element name="auth_time_out">
             <ref name="INTEGER"/>
           </element>
         </optional>
         <optional>
+          <!--
+            Path to an HTTTP(S) server, hard disk, USB driver or similar containing the
+            private/public keys to connect to the master server
+          -->
           <element name="keys_url">
             <text/>
           </element>
         </optional>
         <optional>
+          <!-- Enable the configuration management system services after the installation -->
           <element name="enable_services">
             <ref name="BOOLEAN"/>
           </element>
         </optional>
         <optional>
           <!-- Salt specific -->
-          <element name="formulas_roots">
-            <text/>
-          </element>
-        </optional>
-        <optional>
+          <!-- Path to write Pillar data -->
           <element name="pillar_root">
             <text/>
           </element>
         </optional>
         <optional>
+          <!-- URL to read Pillar data from -->
           <element name="pillar_url">
             <text/>
           </element>
         </optional>
         <optional>
-          <element name="states_roots">
-            <text/>
+          <!-- Paths to search for formulas -->
+          <element name="formulas_roots">
+            <ref name="LIST"/>
+            <oneOrMore>
+              <element name="formulas_root">
+                <text/>
+              </element>
+            </oneOrMore>
           </element>
         </optional>
         <optional>
+          <!-- Paths to search for states -->
+          <element name="states_roots">
+            <ref name="LIST"/>
+            <oneOrMore>
+              <element name="states_root">
+                <text/>
+              </element>
+            </oneOrMore>
+          </element>
+        </optional>
+        <optional>
+          <!-- URL to get states from -->
           <element name="states_url">
             <text/>
           </element>
         </optional>
         <optional>
+          <!-- List of states/formulas to enable -->
           <element name="enabled_states">
             <ref name="LIST"/>
             <oneOrMore>
@@ -2303,6 +2326,7 @@ Valid for all stages if not explicitely defined.</a:documentation>
         </optional>
         <optional>
           <!-- Puppet specific -->
+          <!-- URL to read Puppet modules from -->
           <element name="modules_url">
             <text/>
           </element>

--- a/control/control.rng
+++ b/control/control.rng
@@ -2229,6 +2229,87 @@ Valid for all stages if not explicitely defined.</a:documentation>
     </element>
   </define>
   <!-- update -->
+  <define name="configuration_management">
+    <element name="configuration_management">
+      <interleave>
+        <optional>
+          <element name="type">
+            <choice>
+              <value>salt</value>
+              <value>puppet</value>
+            </choice>
+          </element>
+        </optional>
+        <optional>
+          <element name="master">
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <element name="auth_attempts">
+            <ref name="INTEGER"/>
+          </element>
+        </optional>
+        <optional>
+          <element name="auth_time_out">
+            <ref name="INTEGER"/>
+          </element>
+        </optional>
+        <optional>
+          <element name="keys_url">
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <element name="enable_services">
+            <ref name="BOOLEAN"/>
+          </element>
+        </optional>
+        <optional>
+          <!-- Salt specific -->
+          <element name="formulas_roots">
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <element name="pillar_root">
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <element name="pillar_url">
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <element name="states_roots">
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <element name="states_url">
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <element name="enabled_states">
+            <ref name="LIST"/>
+            <oneOrMore>
+              <element name="state">
+                <text/>
+              </element>
+            </oneOrMore>
+          </element>
+        </optional>
+        <optional>
+          <!-- Puppet specific -->
+          <element name="modules_url">
+            <text/>
+          </element>
+        </optional>
+      </interleave>
+    </element>
+  </define>
   <!-- not more than one partitioning element -->
   <define name="productDefines_elements">
     <interleave>
@@ -2268,6 +2349,9 @@ Valid for all stages if not explicitely defined.</a:documentation>
       <zeroOrMore>
         <ref name="system_roles"/>
       </zeroOrMore>
+      <optional>
+        <ref name="configuration_management"/>
+      </optional>
     </interleave>
   </define>
   <start>

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 17 12:08:31 UTC 2018 - igonzalezsosa@suse.com
+
+- Add a configuration_management section (fate#322722).
+- 4.1.6
+
+-------------------------------------------------------------------
 Fri Dec 14 11:50:09 UTC 2018 - dgonzalez@suse.com
 
 - Add macros related to skelcd (fate#325482)

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.1.5
+Version:        4.1.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Extend the control schema with a `configuration_management` section.

```xml
<configuration_management>
  <formulas_roots config:type="list">
    <listentry>/srv/custom-salt/formulas</listentry>
  </formulas_roots>
  <states_roots config:type="list">
    <listentry>/srv/custom-salt/salt</listentry>
  </states_roots>
  <enabled_states config:type="list">
    <listentry>motd</listentry>
  </enabled_states>
</configuration_management>
```

(edit: the anonymous list item element is `listentry`)