### PR TITLE
Add new elements to partitioning / proposal section

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -571,6 +571,8 @@ partitioning_proposal_elements =
     & ng_other_delete_mode?
     & ng_lvm_vg_strategy?
     & ng_lvm_vg_size?
+    & ng_delete_resize_configurable?
+    & ng_allocate_volume_mode?
     & proposal_settings_editable?
 
 ng_lvm = element lvm { BOOLEAN }
@@ -580,8 +582,11 @@ ng_linux_delete_mode = element linux_delete_mode { SYMBOL, ng_delete_mode_enum }
 ng_other_delete_mode = element other_delete_mode { SYMBOL, ng_delete_mode_enum }
 ng_lvm_vg_strategy = element lvm_vg_strategy { SYMBOL, ng_lvm_vg_strategy_enum }
 ng_lvm_vg_size = element lvm_vg_size { DISKSIZE }
+ng_delete_resize_configurable = element delete_resize_configurable { BOOLEAN }
+ng_allocate_volume_mode = element allocate_volume_mode { SYMBOL, ng_allocate_volume_mode_enum }
 
 ng_delete_mode_enum = "none" | "ondemand" | "all"
+ng_allocate_volume_mode_enum = "auto" | "device"
 ng_lvm_vg_strategy_enum = "use_available" | "use_needed" | "use_vg_size"
 
 partitioning_volumes =  element volumes {

--- a/control/control.rng
+++ b/control/control.rng
@@ -1186,6 +1186,12 @@ Example 2: ppc,!board_powernv
         <ref name="ng_lvm_vg_size"/>
       </optional>
       <optional>
+        <ref name="ng_delete_resize_configurable"/>
+      </optional>
+      <optional>
+        <ref name="ng_allocate_volume_mode"/>
+      </optional>
+      <optional>
         <ref name="proposal_settings_editable"/>
       </optional>
     </interleave>
@@ -1229,11 +1235,28 @@ Example 2: ppc,!board_powernv
       <ref name="DISKSIZE"/>
     </element>
   </define>
+  <define name="ng_delete_resize_configurable">
+    <element name="delete_resize_configurable">
+      <ref name="BOOLEAN"/>
+    </element>
+  </define>
+  <define name="ng_allocate_volume_mode">
+    <element name="allocate_volume_mode">
+      <ref name="SYMBOL"/>
+      <ref name="ng_allocate_volume_mode_enum"/>
+    </element>
+  </define>
   <define name="ng_delete_mode_enum">
     <choice>
       <value>none</value>
       <value>ondemand</value>
       <value>all</value>
+    </choice>
+  </define>
+  <define name="ng_allocate_volume_mode_enum">
+    <choice>
+      <value>auto</value>
+      <value>device</value>
     </choice>
   </define>
   <define name="ng_lvm_vg_strategy_enum">

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 12 15:54:21 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Add the delete_resize_configurable and allocate_volume_mode
+  elements to the partitioning section (part of jsc#SLE-7238).
+- 4.2.3
+
+-------------------------------------------------------------------
 Thu Apr 25 13:26:09 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - fix cpu_mitigations to allow selection(bsc#1098559)

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Both optional, 

* `delete_resize_configurable` | yast/yast-storage-ng#935 |, allows choosing if  the user can decide what to do with existing partitions.
* `allocate_volume_mode`  | yast/yast-storage-ng#936 |, allows including, when set to `device`, a new step in the guided setup through which the user can specify which device must be used to allocate each volume.

---

*Please, see linked PRs for more information.*