### PR TITLE
Add `separate_vgs` and `separate_vg_name` elements

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -623,6 +623,7 @@ partitioning_volume_elements =
   & ng_btrfs_default_subvolume?
   & ng_disable_order?
   & ng_btrfs_read_only?
+  & ng_separate_vg_name?
 
 ng_snapshots_size_or_percentage = ng_snapshots_size | ng_snapshots_percentage
 
@@ -651,6 +652,7 @@ ng_subvolumes = subvolumes
 ng_btrfs_default_subvolume = element btrfs_default_subvolume { text }
 ng_disable_order = element disable_order { INTEGER }
 ng_btrfs_read_only = element btrfs_read_only { BOOLEAN }
+ng_separate_vg_name = element separate_vg_name { text }
 
 ## Partitioning-related variables
 partitioning = element partitioning {

--- a/control/control.rnc
+++ b/control/control.rnc
@@ -565,6 +565,7 @@ partitioning_proposal = element proposal { partitioning_proposal_elements }
 
 partitioning_proposal_elements =
     ng_lvm?
+    & ng_separate_vgs?
     & ng_resize_windows?
     & ng_windows_delete_mode?
     & ng_linux_delete_mode?
@@ -576,6 +577,7 @@ partitioning_proposal_elements =
     & proposal_settings_editable?
 
 ng_lvm = element lvm { BOOLEAN }
+ng_separate_vgs = element separate_vgs { BOOLEAN }
 ng_resize_windows = element resize_windows { BOOLEAN }
 ng_windows_delete_mode = element windows_delete_mode { SYMBOL, ng_delete_mode_enum }
 ng_linux_delete_mode = element linux_delete_mode { SYMBOL, ng_delete_mode_enum }

--- a/control/control.rng
+++ b/control/control.rng
@@ -1361,6 +1361,9 @@ Example 2: ppc,!board_powernv
       <optional>
         <ref name="ng_btrfs_read_only"/>
       </optional>
+      <optional>
+        <ref name="ng_separate_vg_name"/>
+      </optional>
     </interleave>
   </define>
   <define name="ng_snapshots_size_or_percentage">
@@ -1490,6 +1493,11 @@ Example 2: ppc,!board_powernv
   <define name="ng_btrfs_read_only">
     <element name="btrfs_read_only">
       <ref name="BOOLEAN"/>
+    </element>
+  </define>
+  <define name="ng_separate_vg_name">
+    <element name="separate_vg_name">
+      <text/>
     </element>
   </define>
   <define name="partitioning">

--- a/control/control.rng
+++ b/control/control.rng
@@ -1168,6 +1168,9 @@ Example 2: ppc,!board_powernv
         <ref name="ng_lvm"/>
       </optional>
       <optional>
+        <ref name="ng_separate_vgs"/>
+      </optional>
+      <optional>
         <ref name="ng_resize_windows"/>
       </optional>
       <optional>
@@ -1198,6 +1201,11 @@ Example 2: ppc,!board_powernv
   </define>
   <define name="ng_lvm">
     <element name="lvm">
+      <ref name="BOOLEAN"/>
+    </element>
+  </define>
+  <define name="ng_separate_vgs">
+    <element name="separate_vgs">
       <ref name="BOOLEAN"/>
     </element>
   </define>

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul 15 16:08:18 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Add the separate_vgs and separate_vg_name elements
+  (part of jsc#SLE-7238).
+- 4.2.4
+
+-------------------------------------------------------------------
 Fri Jul 12 15:54:21 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Add the delete_resize_configurable and allocate_volume_mode

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
As part of jsc#SLE-7238, the `separate_vgs` and `separate_vg_name` has been added.

Both were introduced in https://github.com/yast/yast-storage-ng/pull/931.

  * `separate_vgs` as element of the partitioning/_proposal_ section.
  * `separate_vg_name` as element of a _volume_ section.

---

Also related to https://github.com/yast/yast-installation-control/pull/86.


