### PR TITLE
Add the `multidisk_first`partitioning proposal option

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -574,6 +574,7 @@ partitioning_proposal_elements =
     & ng_lvm_vg_size?
     & ng_delete_resize_configurable?
     & ng_allocate_volume_mode?
+    & ng_multidisk_first?
     & proposal_settings_editable?
 
 ng_lvm = element lvm { BOOLEAN }
@@ -586,6 +587,7 @@ ng_lvm_vg_strategy = element lvm_vg_strategy { SYMBOL, ng_lvm_vg_strategy_enum }
 ng_lvm_vg_size = element lvm_vg_size { DISKSIZE }
 ng_delete_resize_configurable = element delete_resize_configurable { BOOLEAN }
 ng_allocate_volume_mode = element allocate_volume_mode { SYMBOL, ng_allocate_volume_mode_enum }
+ng_multidisk_first = element multidisk_first { BOOLEAN }
 
 ng_delete_mode_enum = "none" | "ondemand" | "all"
 ng_allocate_volume_mode_enum = "auto" | "device"

--- a/control/control.rng
+++ b/control/control.rng
@@ -1195,6 +1195,9 @@ Example 2: ppc,!board_powernv
         <ref name="ng_allocate_volume_mode"/>
       </optional>
       <optional>
+        <ref name="ng_multidisk_first"/>
+      </optional>
+      <optional>
         <ref name="proposal_settings_editable"/>
       </optional>
     </interleave>
@@ -1252,6 +1255,11 @@ Example 2: ppc,!board_powernv
     <element name="allocate_volume_mode">
       <ref name="SYMBOL"/>
       <ref name="ng_allocate_volume_mode_enum"/>
+    </element>
+  </define>
+  <define name="ng_multidisk_first">
+    <element name="multidisk_first">
+      <ref name="BOOLEAN"/>
     </element>
   </define>
   <define name="ng_delete_mode_enum">

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 19 14:36:52 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Add the multidisk_first option to the partitioning proposal
+  section (related to jsc#SLE-7238).
+- 4.2.5
+
+-------------------------------------------------------------------
 Mon Jul 15 16:08:18 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Add the separate_vgs and separate_vg_name elements

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
As part of jsc#SLE-7238, the `multidisk_first` option has been added to the partitioning/_proposal_ section.

See https://github.com/yast/yast-storage-ng/pull/953


