### PR TITLE
Base products on the online medium (jsc#SLE-7214)

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -315,6 +315,7 @@ software_elements =
     | optional_default_patterns
     | upgrade
     | minimalistic_libzypp_config
+    | base_products
 
 ## The name of the product which should be selected,
 ## useful to choose it without asking the user (bsc#1124590).
@@ -459,6 +460,20 @@ software = element software {
 
 ## Minimalistic libzypp configuration (only requires, no documentation and no multiversion)
 minimalistic_libzypp_config = element minimalistic_libzypp_config { BOOLEAN }
+
+base_products = element base_products {
+    LIST,
+    base_product+
+}
+
+base_product = element base_product {
+    element special_product { BOOLEAN }? &
+    element label { text } &
+    element name { text } &
+    element version { text } &
+    element register_target { text } &
+    element archs { text }?
+}
 
 # software
 

--- a/control/control.rng
+++ b/control/control.rng
@@ -602,6 +602,7 @@ Absolut path is required.</a:documentation>
       <ref name="optional_default_patterns"/>
       <ref name="upgrade"/>
       <ref name="minimalistic_libzypp_config"/>
+      <ref name="base_products"/>
     </choice>
   </define>
   <define name="select_product">
@@ -936,6 +937,42 @@ selected for installation</a:documentation>
     <a:documentation>Minimalistic libzypp configuration (only requires, no documentation and no multiversion)</a:documentation>
     <element name="minimalistic_libzypp_config">
       <ref name="BOOLEAN"/>
+    </element>
+  </define>
+  <define name="base_products">
+    <element name="base_products">
+      <ref name="LIST"/>
+      <oneOrMore>
+        <ref name="base_product"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="base_product">
+    <element name="base_product">
+      <interleave>
+        <optional>
+          <element name="special_product">
+            <ref name="BOOLEAN"/>
+          </element>
+        </optional>
+        <element name="label">
+          <text/>
+        </element>
+        <element name="name">
+          <text/>
+        </element>
+        <element name="version">
+          <text/>
+        </element>
+        <element name="register_target">
+          <text/>
+        </element>
+        <optional>
+          <element name="archs">
+            <text/>
+          </element>
+        </optional>
+      </interleave>
     </element>
   </define>
   <!-- software -->

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 20 15:09:21 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Allow specifying the base products for the online installation
+  medium (jsc#SLE-7214)
+- 4.2.6
+
+-------------------------------------------------------------------
 Tue Aug 27 10:02:50 CEST 2019 - schubi@suse.de
 
 - Adapting Dockerfile to yast-ruby container.

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- Allow specifying the base products for the online installation medium
- See https://jira.suse.com/browse/SLE-7214
- Tested manually
- 4.2.6

Example product definition:

```xml
<base_products config:type="list">
  <base_product>
    <special_product config:type="boolean">true</special_product>
    <label>SUSE Linux Enterprise Server 15 SP2 Business Critical Linux</label>
    <name>SLES_BCL</name>
    <version>15.2</version>
    <register_target>sle-15-$arch</register_target>
    <archs>x86_64</archs>
  </base_product>
  <base_product>
    <label>SUSE Linux Enterprise Server 15 SP2</label>
    <name>SLES</name>
    <version>15.2</version>
    <register_target>sle-15-$arch</register_target>
  </base_product>
</base_products>
```

When adding this excerpt to the `software` section the `control.xml` file validates against this updated schema.