### PR TITLE
Use "display_name" tag for the product label (jsc#SLE-7214)

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -468,7 +468,7 @@ base_products = element base_products {
 
 base_product = element base_product {
     element special_product { BOOLEAN }? &
-    element label { text } &
+    element display_name { text } &
     element name { text } &
     element version { text } &
     element register_target { text } &

--- a/control/control.rng
+++ b/control/control.rng
@@ -955,7 +955,7 @@ selected for installation</a:documentation>
             <ref name="BOOLEAN"/>
           </element>
         </optional>
-        <element name="label">
+        <element name="display_name">
           <text/>
         </element>
         <element name="name">

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 23 07:02:00 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Use "display_name" tag for the product label, "label" marks a
+  translatable text (jsc#SLE-7214)
+- 4.2.7
+
+-------------------------------------------------------------------
 Fri Sep 20 15:09:21 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Allow specifying the base products for the online installation

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.2.6
+Version:        4.2.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- "label" marks a translatable text, avoid translating the product names
- 4.2.7