### PR TITLE
Ip forwarding default

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -696,8 +696,11 @@ network_elements =
     force_static_ip
     | network_manager
     | startmode
+    | ip_forwarding
 
 force_static_ip =	element force_static_ip { BOOLEAN }
+# Default proposal for ip forwarding. See bsc#1163328
+ip_forwarding   =	element ip_forwarding { BOOLEAN }
 network_manager =	element network_manager { text }
 startmode =		element startmode { text }
 

--- a/control/control.rng
+++ b/control/control.rng
@@ -1581,10 +1581,17 @@ Example 2: ppc,!board_powernv
       <ref name="force_static_ip"/>
       <ref name="network_manager"/>
       <ref name="startmode"/>
+      <ref name="ip_forwarding"/>
     </choice>
   </define>
   <define name="force_static_ip">
     <element name="force_static_ip">
+      <ref name="BOOLEAN"/>
+    </element>
+  </define>
+  <!-- Default proposal for ip forwarding. See bsc#1163328 -->
+  <define name="ip_forwarding">
+    <element name="ip_forwarding">
       <ref name="BOOLEAN"/>
     </element>
   </define>

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 24 12:13:31 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Add networking ip_forwarding element to specify default settings
+  for ip forwarding (bsc#1163328)
+- 4.2.10
+
+-------------------------------------------------------------------
 Mon Feb 24 14:52:05 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Allow specifying the default preselected modules in the offline

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.2.9
+Version:        4.2.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
trello: https://trello.com/c/GhjhX2io/1681-6-featurekubic-1163328-kubic-installer-system-role-should-not-disable-ipforward-by-default

bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1163328