### PR TITLE
Add options for installation layout

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -157,6 +157,7 @@ globals_elements =
     | self_update_url
     | self_update_id
     | installation_ui
+    | installation_layout
     | cpu_mitigations
     | full_system_media_name
     | full_system_download_url
@@ -264,8 +265,19 @@ self_update_url =			element self_update_url { STRING }
 ## It is an ID used to query SCC for the self update repo.
 self_update_id =			element self_update_id { STRING }
 # Installation UI (boo#1088785)
-## Enables alternative look of installation with sidebar
+## Enables alternative look of installation with sidebar.
+## This options is deprecated if favor of installation_layout.
 installation_ui =			element installation_ui { "sidebar" }
+## Configures the installation UI layout.
+installation_layout = element installation_layout {
+  MAP,
+  (
+    ## General layout mode
+    element mode { "steps" | "title-on-left" | "title-on-top" }? &
+    ## Top banner where logo is usually placed
+    element banner { BOOLEAN }?
+  )
+}
 # Default value for CPU Mitigation settings in bootloader
 ## possible values are same as for autoyast and in UI - auto, nosmt, off, manual
 ## see ::Bootloader::CpuMitigations.from_string
@@ -652,7 +664,7 @@ partitions = element partitions {
 
 # ng element definitions
 
-partitioning_proposal = element proposal { 
+partitioning_proposal = element proposal {
   MAP,
   partitioning_proposal_elements
 }

--- a/control/control.rng
+++ b/control/control.rng
@@ -236,6 +236,7 @@ Shorter variants are allowed.</a:documentation>
       <ref name="self_update_url"/>
       <ref name="self_update_id"/>
       <ref name="installation_ui"/>
+      <ref name="installation_layout"/>
       <ref name="cpu_mitigations"/>
       <ref name="full_system_media_name"/>
       <ref name="full_system_download_url"/>
@@ -531,9 +532,34 @@ The URL is used as fallback when SCC query failed.</a:documentation>
   </define>
   <!-- Installation UI (boo#1088785) -->
   <define name="installation_ui">
-    <a:documentation>Enables alternative look of installation with sidebar</a:documentation>
+    <a:documentation>Enables alternative look of installation with sidebar.
+This options is deprecated if favor of installation_layout.</a:documentation>
     <element name="installation_ui">
       <value>sidebar</value>
+    </element>
+  </define>
+  <define name="installation_layout">
+    <a:documentation>Configures the installation UI layout.</a:documentation>
+    <element name="installation_layout">
+      <ref name="MAP"/>
+      <interleave>
+        <optional>
+          <element name="mode">
+            <a:documentation>General layout mode</a:documentation>
+            <choice>
+              <value>steps</value>
+              <value>title-on-left</value>
+              <value>title-on-top</value>
+            </choice>
+          </element>
+        </optional>
+        <optional>
+          <element name="banner">
+            <a:documentation>Top banner where logo is usually placed</a:documentation>
+            <ref name="BOOLEAN"/>
+          </element>
+        </optional>
+      </interleave>
     </element>
   </define>
   <!-- Default value for CPU Mitigation settings in bootloader -->

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 22 11:01:03 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Add options to configure the installation layout.
+- Related to jsc#PM-1998.
+- 4.3.3
+
+-------------------------------------------------------------------
 Tue May 26 13:48:56 UTC 2020 - Martin Vidner <martin@frogs>
 
 - Work around Relax-NG parser error: "Found anyName attribute

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Problem

YaST installer and YaST Firstboot look very different because they are using different layout configuration.

The installer layout can be configured thanks to the *installation_ui* setting in the control file, but YaST Firstboot is ignoring that setting.

Moreover, *installation_ui* only allows some specific layout configurations, and it affects to several layout parts at the same time. Basically, it only offers two possible configurations:

* *installation_ui = sidebar*: shows the left sidebar with the installation steps and hides the top banner (used by openSUSE).
* otherwise: does now show the left sidebar and shows the top banner (used by SLE).

There are more possible layout configurations that cannot be accomplished by using *installation_ui* option.

* Related to https://jira.suse.com/browse/PM-1998.

## Solution

*installation_ui* is deprecated if favor of *installation_layout*. This new setting makes possible to configure each layout part separately (mode and banner).

The *mode* allows three possible values: *steps*, *title-on-left*, *title-on-top*. For each one, the banner can be shown/hidden. For example, current openSUSE layout can be configured as:

~~~
<globals>
  <installation_layout>
    <mode>steps</mode>
    <banner>false</banner
  </installation_layout>
</globals>
~~~

And SLE flavor with:

~~~
<globals>
  <installation_layout>
    <mode>title-on-left</mode>
    <banner>true</banner
  </installation_layout>
</globals>
~~~

These new settings should be considered by both: the installation and firstboot clients. Note that a new *UI::Installation::Layout* class is now provided by *yast2* to ease the layout configuration according these settings, see https://github.com/yast/yast-yast2/pull/1080.
