### PR TITLE
Add SELinux control variables

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -140,6 +140,7 @@ globals_elements =
     | full_system_download_url
     | precise_time
     | selinux_mode
+    | selinux_configurable
 
 ## Default kernel parameters proposed by bootloader
 additional_kernel_parameters =		element additional_kernel_parameters { text }
@@ -259,6 +260,9 @@ full_system_download_url =		element full_system_download_url { text }
 precise_time =		        	element precise_time { BOOLEAN }
 ## SELinux mode: allows to choose the SELinux mode to be proposed (related to jsc#SLE-17427)
 selinux_mode = element selinux_mode { "disabled" | "permissive" | "enforcing" }
+## SELinux configurable: whether SELinux can be proposed/configured during installation
+## (related to jsc#SLE-17427)
+selinux_configurable = element selinux_configurable { BOOLEAN }
 
 ## Defines which pieces of installation system should be copied to
 ## the installed system before rebooting to second stage.

--- a/control/control.rnc
+++ b/control/control.rnc
@@ -139,6 +139,7 @@ globals_elements =
     | full_system_media_name
     | full_system_download_url
     | precise_time
+    | selinux_mode
 
 ## Default kernel parameters proposed by bootloader
 additional_kernel_parameters =		element additional_kernel_parameters { text }
@@ -256,6 +257,8 @@ full_system_media_name =		element full_system_media_name { text }
 full_system_download_url =		element full_system_download_url { text }
 ## Defines if product needs precise time. It is short time workaround for bsc#1145193
 precise_time =		        	element precise_time { BOOLEAN }
+## SELinux mode: allows to choose the SELinux mode to be proposed (related to jsc#SLE-17427)
+selinux_mode = element selinux_mode { "disabled" | "permissive" | "enforcing" }
 
 ## Defines which pieces of installation system should be copied to
 ## the installed system before rebooting to second stage.

--- a/control/control.rng
+++ b/control/control.rng
@@ -177,6 +177,7 @@
       <ref name="full_system_download_url"/>
       <ref name="precise_time"/>
       <ref name="selinux_mode"/>
+      <ref name="selinux_configurable"/>
     </choice>
   </define>
   <define name="additional_kernel_parameters">
@@ -518,6 +519,13 @@ see ::Bootloader::CpuMitigations.from_string</a:documentation>
         <value>permissive</value>
         <value>enforcing</value>
       </choice>
+    </element>
+  </define>
+  <define name="selinux_configurable">
+    <a:documentation>SELinux configurable: whether SELinux can be proposed/configured during installation
+(related to jsc#SLE-17427)</a:documentation>
+    <element name="selinux_configurable">
+      <ref name="BOOLEAN"/>
     </element>
   </define>
   <define name="save_instsys_content">

--- a/control/control.rng
+++ b/control/control.rng
@@ -176,6 +176,7 @@
       <ref name="full_system_media_name"/>
       <ref name="full_system_download_url"/>
       <ref name="precise_time"/>
+      <ref name="selinux_mode"/>
     </choice>
   </define>
   <define name="additional_kernel_parameters">
@@ -507,6 +508,16 @@ see ::Bootloader::CpuMitigations.from_string</a:documentation>
     <a:documentation>Defines if product needs precise time. It is short time workaround for bsc#1145193</a:documentation>
     <element name="precise_time">
       <ref name="BOOLEAN"/>
+    </element>
+  </define>
+  <define name="selinux_mode">
+    <a:documentation>SELinux mode: allows to choose the SELinux mode to be proposed (related to jsc#SLE-17427)</a:documentation>
+    <element name="selinux_mode">
+      <choice>
+        <value>disabled</value>
+        <value>permissive</value>
+        <value>enforcing</value>
+      </choice>
     </element>
   </define>
   <define name="save_instsys_content">

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Feb  3 15:18:01 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Add 'selinux_mode' and 'selinux_configurable' variables to control
+  the SELinux configuration to be proposed (jsc#SLE-17427,
+  jsc#SLE-17307).
+- 4.2.11
+
+-------------------------------------------------------------------
 Wed Oct  7 17:11:29 CEST 2020 - schubi@suse.de
 
 - Upgrade openSUSE->Jump. Allow vendor change without asking

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.2.10
+Version:        4.2.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Related to https://github.com/yast/yast-security/pull/83, it adds `selinux_mode` and `selinux_configurable` needed variables to set the proposed SELinux mode via kernel options.

* `selinux_mode` can be _disabled_, _permissive_, or _enforcing_
* `selinux_configurable` determines if the SELinux mode can be adjusted during installation. If so, the installer will propose the set `selinux_mode`

---

Related (and internal) links:

* https://trello.com/c/g94xQBDM
* https://jira.suse.com/browse/SMO-20
* https://jira.suse.com/browse/SLE-17427