### PR TITLE
Add 'patterns' SELinux control variable

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -139,8 +139,7 @@ globals_elements =
     | full_system_media_name
     | full_system_download_url
     | precise_time
-    | selinux_mode
-    | selinux_configurable
+    | selinux
 
 ## Default kernel parameters proposed by bootloader
 additional_kernel_parameters =		element additional_kernel_parameters { text }
@@ -258,11 +257,16 @@ full_system_media_name =		element full_system_media_name { text }
 full_system_download_url =		element full_system_download_url { text }
 ## Defines if product needs precise time. It is short time workaround for bsc#1145193
 precise_time =		        	element precise_time { BOOLEAN }
-## SELinux mode: allows to choose the SELinux mode to be proposed (related to jsc#SLE-17427)
-selinux_mode = element selinux_mode { "disabled" | "permissive" | "enforcing" }
-## SELinux configurable: whether SELinux can be proposed/configured during installation
-## (related to jsc#SLE-17427)
-selinux_configurable = element selinux_configurable { BOOLEAN }
+## SELinux options
+selinux = element selinux {
+  MAP,
+    (
+      ## SELinux mode
+      element mode { "disabled" | "permissive" | "enforcing" }? &
+      ## Whether SELinux can be proposed/configured during installation
+      element configurable { BOOLEAN }?
+    )
+}
 
 ## Defines which pieces of installation system should be copied to
 ## the installed system before rebooting to second stage.

--- a/control/control.rnc
+++ b/control/control.rnc
@@ -264,7 +264,9 @@ selinux = element selinux {
       ## SELinux mode
       element mode { "disabled" | "permissive" | "enforcing" }? &
       ## Whether SELinux can be proposed/configured during installation
-      element configurable { BOOLEAN }?
+      element configurable { BOOLEAN }? &
+      ## Required/Suggested patterns when using SELinux
+      element patterns { text }?
     )
 }
 

--- a/control/control.rnc
+++ b/control/control.rnc
@@ -265,7 +265,7 @@ selinux = element selinux {
       element mode { "disabled" | "permissive" | "enforcing" }? &
       ## Whether SELinux can be proposed/configured during installation
       element configurable { BOOLEAN }? &
-      ## Required/Suggested patterns when using SELinux
+      ## Space-separated list of required/suggested patterns when using SELinux
       element patterns { text }?
     )
 }

--- a/control/control.rng
+++ b/control/control.rng
@@ -531,6 +531,12 @@ see ::Bootloader::CpuMitigations.from_string</a:documentation>
             <ref name="BOOLEAN"/>
           </element>
         </optional>
+        <optional>
+          <element name="patterns">
+            <a:documentation>Required/Suggested patterns when using SELinux</a:documentation>
+            <text/>
+          </element>
+        </optional>
       </interleave>
     </element>
   </define>

--- a/control/control.rng
+++ b/control/control.rng
@@ -176,8 +176,7 @@
       <ref name="full_system_media_name"/>
       <ref name="full_system_download_url"/>
       <ref name="precise_time"/>
-      <ref name="selinux_mode"/>
-      <ref name="selinux_configurable"/>
+      <ref name="selinux"/>
     </choice>
   </define>
   <define name="additional_kernel_parameters">
@@ -511,21 +510,28 @@ see ::Bootloader::CpuMitigations.from_string</a:documentation>
       <ref name="BOOLEAN"/>
     </element>
   </define>
-  <define name="selinux_mode">
-    <a:documentation>SELinux mode: allows to choose the SELinux mode to be proposed (related to jsc#SLE-17427)</a:documentation>
-    <element name="selinux_mode">
-      <choice>
-        <value>disabled</value>
-        <value>permissive</value>
-        <value>enforcing</value>
-      </choice>
-    </element>
-  </define>
-  <define name="selinux_configurable">
-    <a:documentation>SELinux configurable: whether SELinux can be proposed/configured during installation
-(related to jsc#SLE-17427)</a:documentation>
-    <element name="selinux_configurable">
-      <ref name="BOOLEAN"/>
+  <define name="selinux">
+    <a:documentation>SELinux options</a:documentation>
+    <element name="selinux">
+      <ref name="MAP"/>
+      <interleave>
+        <optional>
+          <element name="mode">
+            <a:documentation>SELinux mode</a:documentation>
+            <choice>
+              <value>disabled</value>
+              <value>permissive</value>
+              <value>enforcing</value>
+            </choice>
+          </element>
+        </optional>
+        <optional>
+          <element name="configurable">
+            <a:documentation>Whether SELinux can be proposed/configured during installation</a:documentation>
+            <ref name="BOOLEAN"/>
+          </element>
+        </optional>
+      </interleave>
     </element>
   </define>
   <define name="save_instsys_content">

--- a/control/control.rng
+++ b/control/control.rng
@@ -533,7 +533,7 @@ see ::Bootloader::CpuMitigations.from_string</a:documentation>
         </optional>
         <optional>
           <element name="patterns">
-            <a:documentation>Required/Suggested patterns when using SELinux</a:documentation>
+            <a:documentation>Space-separated list of required/suggested patterns when using SELinux</a:documentation>
             <text/>
           </element>
         </optional>

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -9,8 +9,8 @@ Wed Feb 10 13:43:33 UTC 2021 - David Diaz <dgonzalez@suse.com>
 Wed Feb  3 15:18:01 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Add 'selinux_mode' and 'selinux_configurable' variables to control
-  the SELinux configuration to be proposed (jsc#SLE-17427,
-  jsc#SLE-17307).
+  the SELinux configuration to be proposed (jsc#SMO-20,
+  jsc#SLE-17342).
 - 4.2.11
 
 -------------------------------------------------------------------

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 10 13:43:33 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Group 'mode' and 'configurable' SELinux variable.
+- Add 'patterns' SELinux variable (jsc#SMO-20, jsc#SLE-17342).
+- 4.2.12
+
+-------------------------------------------------------------------
 Wed Feb  3 15:18:01 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Add 'selinux_mode' and 'selinux_configurable' variables to control

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.2.11
+Version:        4.2.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Since the recommended/required pattern(s) to have SELinux working as expected might be different depending on the code stream, a new `patterns` SELinux control variable has been added for specifying it/them.

**Note** that previously added (see #107) SELinux control variables have been moved to `<selinux>` element in order to keep all of them grouped.

Thus, `<selinux_mode>` and `<selinux_configurable>` does not exist anymore. Instead, SELinux options should be defined as follow

```xml

<globals>
  ...
  <selinux>
    <mode>enforcing</mode>
    <configurable config:type="boolean">true</configurable>
    <patterns>microos-selinux</patterns>
  </selinux>
  ...
</globals>
```

---

<sub>Also fix the changelog file using more accurate Jira reference for previous version</sub>