### PR TITLE
Add options for defining IP forwarding defaults (bsc#1186280)

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -818,10 +818,15 @@ network_elements =
     force_static_ip
     | network_manager
     | startmode
+    | ipv4_forward
+    | ipv6_forward
 
 force_static_ip =	element force_static_ip { BOOLEAN }
 network_manager =	element network_manager { STRING }
 startmode =		element startmode { STRING }
+ipv4_forward = element ipv4_forward { BOOLEAN }
+ipv6_forward = element ipv6_forward { BOOLEAN }
+
 
 ## Network configuration-related variables
 network = element network {

--- a/control/control.rng
+++ b/control/control.rng
@@ -1785,6 +1785,8 @@ Example 2: ppc,!board_powernv
       <ref name="force_static_ip"/>
       <ref name="network_manager"/>
       <ref name="startmode"/>
+      <ref name="ipv4_forward"/>
+      <ref name="ipv6_forward"/>
     </choice>
   </define>
   <define name="force_static_ip">
@@ -1800,6 +1802,16 @@ Example 2: ppc,!board_powernv
   <define name="startmode">
     <element name="startmode">
       <ref name="STRING"/>
+    </element>
+  </define>
+  <define name="ipv4_forward">
+    <element name="ipv4_forward">
+      <ref name="BOOLEAN"/>
+    </element>
+  </define>
+  <define name="ipv6_forward">
+    <element name="ipv6_forward">
+      <ref name="BOOLEAN"/>
     </element>
   </define>
   <define name="network">

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 31 07:50:39 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Allow to modify IPv4 and IPv6 forwarding defaults (bsc#1186280)
+- 4.4.2
+
+-------------------------------------------------------------------
 Tue Apr 20 18:14:05 UTC 2021 - Dirk Müller <dmueller@suse.com>
 
 - stop packaging docdir, it only contained the license which

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST2 - RNG schema for installation control files
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

In order to make forwarding configurable during installation we need to add the options to the control file.

- https://trello.com/c/Jao9dDKQ/2477-5-make-forwarding-configurable-for-installer

## Solution

- Added **ipv4_forward** and **ipv6_forward** boolean elements to the control file (used the same than in the AutoYaST networking schema)

```xml
    <!-- Example -->
    <network>
        <ipv4_forward>true</ipv4_forward>
    </network>

    <system_roles config:type="list">
      <system_role>
        <id>kubic_admin_role</id>

        <network>
          <ipv6_forward>true</ipv6_forward>
        </network>

```

---

Related to

* https://bugzilla.suse.com/show_bug.cgi?id=1186280
* https://github.com/yast/yast-network/pull/1229
