### PR TITLE
Fix default ntp server list definition (bsc#1180699)

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -300,7 +300,7 @@ propose_hibernation =	        	element propose_hibernation { BOOLEAN }
 ## Used mainly to distinguish between openSUSE and SUSE products. See bsc#1180699
 default_ntp_servers = element default_ntp_servers {
   LIST,
-  element ntp_server { STRING }
+  element ntp_server { STRING }*
 }
 ## SELinux options
 selinux = element selinux {

--- a/control/control.rng
+++ b/control/control.rng
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+  
   IMPORTANT!: After editing control.rnc run "make" to generate the
   RNG file and commit _both_ files to Git to keep them in sync!
-
+  
   We do not generate the RNG file at build time as it adds huge dependecy (it
   is a Java tool so it requires complete Java stack)
-
+  
 -->
 <grammar ns="http://www.suse.com/1.0/yast2ns" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:config="http://www.suse.com/1.0/configns" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <!--
@@ -614,9 +614,11 @@ by default true</a:documentation>
 Used mainly to distinguish between openSUSE and SUSE products. See bsc#1180699</a:documentation>
     <element name="default_ntp_servers">
       <ref name="LIST"/>
-      <element name="ntp_server">
-        <ref name="STRING"/>
-      </element>
+      <zeroOrMore>
+        <element name="ntp_server">
+          <ref name="STRING"/>
+        </element>
+      </zeroOrMore>
     </element>
   </define>
   <define name="selinux">

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep  6 15:08:30 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix default ntp servers definition allowing zero or multiple
+  server entries (bsc#1180699).
+- 4.4.3
+
+-------------------------------------------------------------------
 Mon May 31 07:50:39 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Allow to modify IPv4 and IPv6 forwarding defaults (bsc#1186280)

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Summary:        YaST2 - RNG schema for installation control files
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

The original definition introduced in #105 does not allow more than one NTP server as it has been reported by https://github.com/yast/skelcd-control-openSUSE/pull/223/checks?check_run_id=3522806900.

- https://trello.com/c/HtBLfvR0/2280-3-ostumbleweed-p5-1180699-microos-defaults-to-using-the-suse-ntp-pool

## Solution

Allow to define **0** or more default ntp servers.