### PR TITLE
Add mount options

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -689,6 +689,7 @@ partitioning_volume = element volume {
 
 partitioning_volume_elements =
   mount_point?
+  & mount_options?
   & proposed?
   & proposed_configurable?
   & fs_types?
@@ -717,6 +718,7 @@ partitioning_volume_elements =
 snapshots_size_or_percentage = snapshots_size | snapshots_percentage
 
 mount_point = element mount_point { STRING }
+mount_options = element mount_options { STRING }
 proposed = element proposed { BOOLEAN }
 proposed_configurable = element proposed_configurable { BOOLEAN }
 fs_types = element fs_types { STRING }

--- a/control/control.rng
+++ b/control/control.rng
@@ -1413,6 +1413,9 @@ Example 2: ppc,!board_powernv
         <ref name="mount_point"/>
       </optional>
       <optional>
+        <ref name="mount_options"/>
+      </optional>
+      <optional>
         <ref name="proposed"/>
       </optional>
       <optional>
@@ -1494,6 +1497,11 @@ Example 2: ppc,!board_powernv
   </define>
   <define name="mount_point">
     <element name="mount_point">
+      <ref name="STRING"/>
+    </element>
+  </define>
+  <define name="mount_options">
+    <element name="mount_options">
       <ref name="STRING"/>
     </element>
   </define>

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec  9 13:00:27 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Partitioning section: add mount_options for volumes (related to
+  fate#318196).
+- 4.4.5
+
+-------------------------------------------------------------------
 Fri Nov  5 12:32:44 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Partitioning section: dropped support for the legacy format of

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.4.4
+Version:        4.4.5
 Release:        0
 Summary:        YaST2 - RNG schema for installation control files
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Mount options can be configured in the AutoYaST profile by means of the *fstopt* attribute. But there is no way to configure the mount options for the mount points indicated in the installation control file.

* https://trello.com/c/NITXJzLx/1745-3-mount-options-for-a-volume-in-the-partitioning-section-of-controlxml

## Solution

Add a new *mount_options* attribute for the partitioning volumes. Note that a Btrfs subvolume can also have a mount point. Currently, the mount point of the subvolume is automatically assigned by YaST based on the subvolume path.

Configuring the mount point of the subvolume was not added yet to the control file. We can reconsider it after adding support for configuring the subvomule mount point in the Expert Partitioner.
