### PR TITLE
LSM section: Added 'none' subsection allowing to mark the module as not selectable

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -321,6 +321,7 @@ lsm = element lsm { MAP,
     lsm_select? &
     lsm_configurable? &
     lsm_selectable? &
+    none_module? &
     selinux? &
     apparmor?
   )
@@ -333,9 +334,15 @@ lsm_module =
   | lsm_selectable
   | lsm_patterns
 
+
 ## AppArmor options
 apparmor = element apparmor { MAP,
   lsm_module*
+}
+
+# None options
+none_module = element none { MAP,
+  lsm_selectable?
 }
 
 ## SELinux mode

--- a/control/control.rng
+++ b/control/control.rng
@@ -663,6 +663,9 @@ Whether the module can be proposed/configured during installation</a:documentati
           <ref name="lsm_selectable"/>
         </optional>
         <optional>
+          <ref name="none_module"/>
+        </optional>
+        <optional>
           <ref name="selinux"/>
         </optional>
         <optional>
@@ -695,6 +698,15 @@ Whether the module can be proposed/configured during installation</a:documentati
       <zeroOrMore>
         <ref name="lsm_module"/>
       </zeroOrMore>
+    </element>
+  </define>
+  <!-- None options -->
+  <define name="none_module">
+    <element name="none">
+      <ref name="MAP"/>
+      <optional>
+        <ref name="lsm_selectable"/>
+      </optional>
     </element>
   </define>
   <define name="selinux_mode">

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jan 11 09:00:19 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+Related to jsc#SLE-22069:
+  - LSM section: added "none" section in order to mark it as not
+    selectable during the installation.
+- 4.4.9
+
+-------------------------------------------------------------------
 Tue Jan  4 11:47:25 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - LSM section: added "selectable" option to the section

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.4.8
+Version:        4.4.9
 Release:        0
 Summary:        YaST2 - RNG schema for installation control files
 License:        GPL-2.0-only


### PR DESCRIPTION
Same option added for AutoYaST, see https://github.com/yast/yast-security/pull/120