### PR TITLE
enable_systemd_boot: systemd_boot can be selected if UEFI is available

### DIFF
--- a/control/control.rnc
+++ b/control/control.rnc
@@ -122,7 +122,7 @@ globals_elements =
     | display_register_forcereg
     | displaymanager_shutdown
     | enable_autologin
-    | enable_autologin
+    | enable_systemd_boot
     | enable_clone
     | enable_firewall
     | enable_kdump
@@ -209,6 +209,8 @@ default_target =				element default_target { STRING }
 debug_workflow =			element debug_workflow { BOOLEAN }
 ## Default value for autologin
 enable_autologin =			element enable_autologin { BOOLEAN }
+## systemd_boot can be selected if UEFI is available
+enable_systemd_boot =			element enable_systemd_boot { BOOLEAN }
 ## Default value for firewall
 enable_firewall =			element enable_firewall { BOOLEAN }
 ## Default value for opening port for SSH in firewall

--- a/control/control.rng
+++ b/control/control.rng
@@ -201,7 +201,7 @@ Shorter variants are allowed.</a:documentation>
       <ref name="display_register_forcereg"/>
       <ref name="displaymanager_shutdown"/>
       <ref name="enable_autologin"/>
-      <ref name="enable_autologin"/>
+      <ref name="enable_systemd_boot"/>
       <ref name="enable_clone"/>
       <ref name="enable_firewall"/>
       <ref name="enable_kdump"/>
@@ -348,6 +348,12 @@ more detailed log entries</a:documentation>
   <define name="enable_autologin">
     <a:documentation>Default value for autologin</a:documentation>
     <element name="enable_autologin">
+      <ref name="BOOLEAN"/>
+    </element>
+  </define>
+  <define name="enable_systemd_boot">
+    <a:documentation>systemd_boot can be selected if UEFI is available</a:documentation>
+    <element name="enable_systemd_boot">
       <ref name="BOOLEAN"/>
     </element>
   </define>

--- a/package/yast2-installation-control.changes
+++ b/package/yast2-installation-control.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug  4 13:03:33 UTC 2023 - Stefan Schubert <schubi@suse.com>
+
+- enable_systemd_boot: systemd_boot can be selected if UEFI is
+  available
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-installation-control.spec
+++ b/package/yast2-installation-control.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation-control
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - RNG schema for installation control files
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

In the future YaST should support systemd-boot too, but each product should be able to
decide if this option is available.

It seems that enable_autologin has been double defined.